### PR TITLE
Multi-arch support: allowing finding new dependencies based on the os and arch platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,7 @@ See: [Buildpack Dependency Management Improvement Overview RFC](https://github.c
 ## Retrieval
 
 The `retrieve` subpackage has an entrypoint func called `NewMetadata` that takes in a buildpack id.
+
+In addition the `retrieve` subpackage has an entrypoint func called `NewMetadataWithPlatform` which supports multi-arch dependency updates that takes in a buildpack id.
+
 See the `godoc` for that package for additional information.

--- a/retrieve/generate_all_metadata_example_test.go
+++ b/retrieve/generate_all_metadata_example_test.go
@@ -38,3 +38,36 @@ func ExampleGenerateAllMetadata() {
 	// Generating metadata for 7.8.9, with targets [target1, target2, target3]
 
 }
+
+func ExampleGenerateAllMetadataWithPlatform() {
+
+	versions, _ := versionology.NewSimpleVersionFetcherArray("1.2.3", "4.5.6", "7.8.9")
+
+	generateMetadataWithPlatform := func(version versionology.VersionFetcher, platform retrieve.Platform) ([]versionology.Dependency, error) {
+		dep := cargo.ConfigMetadataDependency{ID: "dep-id", Version: version.Version().String()}
+
+		switch version.Version().String() {
+		case "1.2.3":
+			return versionology.NewDependencyArray(dep, "target1")
+		case "4.5.6":
+			dep1, _ := versionology.NewDependency(dep, "target1")
+			dep2, _ := versionology.NewDependency(dep, "target2")
+			return []versionology.Dependency{dep1, dep2}, nil
+		case "7.8.9":
+			dep1, _ := versionology.NewDependency(dep, "target1")
+			dep2, _ := versionology.NewDependency(dep, "target2")
+			dep3, _ := versionology.NewDependency(dep, "target3")
+			return []versionology.Dependency{dep1, dep2, dep3}, nil
+		default:
+			panic("unknown version")
+		}
+	}
+
+	retrieve.GenerateAllMetadataWithPlatform(versions, generateMetadataWithPlatform, retrieve.Platform{OS: "linux", Arch: "amd64"})
+
+	// Output:
+	// Generating metadata for 1.2.3, platform linux/amd64, with stacks [target1]
+	// Generating metadata for 4.5.6, platform linux/amd64, with stacks [target1, target2]
+	// Generating metadata for 7.8.9, platform linux/amd64, with stacks [target1, target2, target3]
+
+}

--- a/retrieve/init_test.go
+++ b/retrieve/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestUnitRetrieve(t *testing.T) {
 	suite := spec.New("retrieve", spec.Report(report.Terminal{}))
 	suite("NewMetadata", testNewMetadata, spec.Sequential())
+	suite("NewMetadataWithPlatforms", testNewMetadataWithPlatforms, spec.Sequential())
 	suite("GetNewVersionsForId", testGetNewVersionsForId, spec.Sequential())
 	suite("purl", testPurl)
 	suite.Run(t)

--- a/retrieve/new_metadata_with_platforms_test.go
+++ b/retrieve/new_metadata_with_platforms_test.go
@@ -1,0 +1,196 @@
+package retrieve_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libdependency/retrieve"
+	"github.com/paketo-buildpacks/libdependency/versionology"
+	"github.com/paketo-buildpacks/occam/matchers"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+)
+
+func testNewMetadataWithPlatforms(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		output string
+
+		getAllVersions               retrieve.GetAllVersionsFunc
+		generateMetadataWithPlatform retrieve.GenerateMetadataWithPlatformFunc
+		transformPlatforms           retrieve.TransformsPlatformsFunc
+	)
+
+	it.Before(func() {
+		output = filepath.Join(t.TempDir(), "metadata.json")
+	})
+
+	context("given fake versions and fake metadata", func() {
+		it.Before(func() {
+			retrieve.FetchArgs = func() (string, string) {
+				buildpackTomlPath := filepath.Join("testdata", "happy_path", "buildpack.toml")
+				return buildpackTomlPath, output
+			}
+
+			getAllVersions = func() (versionology.VersionFetcherArray, error) {
+				return versionology.VersionFetcherArray{
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.0.0")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.1.0")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.2.0")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.3.0")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.4.0")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("1.5.0")),
+				}, nil
+			}
+
+			generateMetadataWithPlatform = func(versionFetcher versionology.VersionFetcher, platform retrieve.Platform) ([]versionology.Dependency, error) {
+				dependency := cargo.ConfigMetadataDependency{
+					ID:      "fake-dependency-id",
+					Stacks:  []string{"jammy-stack", "bionic-stack"},
+					Version: versionFetcher.Version().String(),
+				}
+
+				return versionology.NewDependencyArray(dependency, "linux-64")
+			}
+
+			transformPlatforms = func(platforms []retrieve.Platform) []retrieve.Platform {
+				var transformed []retrieve.Platform
+
+				if len(platforms) == 0 {
+					platforms = append(platforms, retrieve.Platform{
+						OS:   "linux",
+						Arch: "amd64",
+					})
+				}
+
+				for i := range platforms {
+					if platforms[i].Arch == "amd64" {
+						platforms[i].Arch = "x64"
+					}
+					transformed = append(transformed, platforms[i])
+				}
+				return transformed
+			}
+		})
+
+		it("should generate metadata.json in the output dir", func() {
+			retrieve.NewMetadataWithPlatforms("fake-dependency-id", getAllVersions, generateMetadataWithPlatform, transformPlatforms)
+
+			Expect(output).To(matchers.BeAFileMatching(MatchJSON(`
+	[
+		{"id":"fake-dependency-id","stacks":["jammy-stack","bionic-stack"],"version":"1.5.0","target":"linux-64"},
+		{"id":"fake-dependency-id","stacks":["jammy-stack","bionic-stack"],"version":"1.4.0","target":"linux-64"}
+	]`)))
+		})
+	})
+
+	context("cpython", func() {
+		it.Before(func() {
+			retrieve.FetchArgs = func() (string, string) {
+				buildpackTomlPath := filepath.Join("testdata", "cpython-de13b843", "buildpack.toml")
+				return buildpackTomlPath, output
+			}
+
+			getAllVersions = func() (versionology.VersionFetcherArray, error) {
+				return versionology.NewSimpleVersionFetcherArray("3.10.5", "3.10.6", "3.10.7", "3.10.8", "3.10.9", "3.10.10")
+			}
+
+			generateMetadataWithPlatform = func(versionFetcher versionology.VersionFetcher, platform retrieve.Platform) ([]versionology.Dependency, error) {
+				dependency := cargo.ConfigMetadataDependency{
+					ID:      "python",
+					Stacks:  []string{"io.buildpacks.stacks.jammy"},
+					Version: versionFetcher.Version().String(),
+				}
+
+				return versionology.NewDependencyArray(dependency, "jammy")
+			}
+
+			transformPlatforms = func(platforms []retrieve.Platform) []retrieve.Platform {
+				var transformed []retrieve.Platform
+
+				if len(platforms) == 0 {
+					platforms = append(platforms, retrieve.Platform{
+						OS:   "linux",
+						Arch: "amd64",
+					})
+				}
+
+				for i := range platforms {
+					if platforms[i].Arch == "amd64" {
+						platforms[i].Arch = "x64"
+					}
+					transformed = append(transformed, platforms[i])
+				}
+				return transformed
+			}
+		})
+
+		it("should only generate metadata for the two newest versions", func() {
+			retrieve.NewMetadataWithPlatforms("python", getAllVersions, generateMetadataWithPlatform, transformPlatforms)
+
+			Expect(output).To(matchers.BeAFileMatching(MatchJSON(`
+	[
+		{"id":"python","stacks":["io.buildpacks.stacks.jammy"],"version":"3.10.10","target":"jammy"},
+		{"id":"python","stacks":["io.buildpacks.stacks.jammy"],"version":"3.10.9","target":"jammy"}
+	]`)))
+		})
+	})
+
+	context("when the dependency id is not found in buildpack.toml", func() {
+		it.Before(func() {
+			retrieve.FetchArgs = func() (string, string) {
+				buildpackTomlPath := filepath.Join("testdata", "happy_path", "buildpack.toml")
+				return buildpackTomlPath, output
+			}
+
+			getAllVersions = func() (versionology.VersionFetcherArray, error) {
+				return versionology.VersionFetcherArray{
+					versionology.NewSimpleVersionFetcher(semver.MustParse("999.888.777")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("666.555.444")),
+					versionology.NewSimpleVersionFetcher(semver.MustParse("333.222.111")),
+				}, nil
+			}
+
+			generateMetadataWithPlatform = func(versionFetcher versionology.VersionFetcher, platform retrieve.Platform) ([]versionology.Dependency, error) {
+				dependency := cargo.ConfigMetadataDependency{
+					ID:      "not a real dependency id",
+					Version: versionFetcher.Version().String(),
+				}
+
+				return versionology.NewDependencyArray(dependency, "jammy")
+			}
+
+			transformPlatforms = func(platforms []retrieve.Platform) []retrieve.Platform {
+				var transformed []retrieve.Platform
+
+				if len(platforms) == 0 {
+					platforms = append(platforms, retrieve.Platform{
+						OS:   "linux",
+						Arch: "amd64",
+					})
+				}
+
+				for i := range platforms {
+					if platforms[i].Arch == "amd64" {
+						platforms[i].Arch = "x64"
+					}
+					transformed = append(transformed, platforms[i])
+				}
+				return transformed
+			}
+		})
+
+		it("all versions are found in the metadata.json", func() {
+			retrieve.NewMetadataWithPlatforms("not a real dependency id", getAllVersions, generateMetadataWithPlatform, transformPlatforms)
+
+			Expect(output).To(matchers.BeAFileMatching(MatchJSON(`
+	[
+		{"id":"not a real dependency id","version":"999.888.777","target":"jammy"},
+		{"id":"not a real dependency id","version":"666.555.444","target":"jammy"},
+		{"id":"not a real dependency id","version":"333.222.111","target":"jammy"}
+	]`)))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR introduces a new function called `NewMetadataWithPlatforms`, which is similar to the `NewMetadata` function, with the only difference being that it iterates over the platforms, where for each platform finds the new dependencies that need to be added on the buildpack.toml. The platforms array, is being fetched from the buildpack.toml from the targets variables

```yaml
[[targets]]
  os = "linux"
  arch = "amd64"

[[targets]]
  os = "linux"
  arch = "arm64"
```
Despite  `NewMetadataWithPlatforms` and `NewMetadata` are very similar and it could possible be one function, due to libdependency is at the core of the tools, I believe is better to create a separate function along with the `NewMetadata` to avoid any unexpected erros on the update dependencies workflow, as on the integration tests of the buildpacks the update dependencies workflow is not being tested on each pull request and also there is not a full test coverage for each scenario of how the `NewMetadata` function is being used on each buildpack on the libdependency repo. Therefore, we can little by little replace the `NewMetadata` with the `NewMetadataWithPlatforms` on the make retrieve workflow  in case we want a buildpack to support updating each dependencies based on platform(os/arch) . See the full list of the function that needs to be replaced in case we want to support updating dependencies based on the platform https://github.com/search?q=org%3Apaketo-buildpacks+retrieve.NewMetadata&type=code

## Use Cases
<!-- An explanation of the use cases your change enables -->

Creates the metadata.json with the new dependencies that need to be added on the buildpack.toml for each platform specified from the buildpack.toml 

This requires on the buildpack.toml, to be specified the os and arch like so

```yml
[[targets]]
  os = "linux"
  arch = "arm64"
```

In that case, for each dependency, the function will add `os` and `arch` attributes on the metadata.json


For easier review, please do a diff between the `NewMetadataWithPlatforms` and `NewMetadata` functions to see how the multi-arch support implementation differs from the single arch.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
